### PR TITLE
v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,6 @@ cpal = "0.15"
 device_query = "4.0"
 crossbeam-channel = "0.5"
 ctrlc = "3.4"
-<<<<<<< HEAD
-=======
-rdev = "0.5"
-rodio = "0.19"
-core-foundation = "0.9"
->>>>>>> 56d9cf80e25c3b66073c1e646f13ade10f2235eb
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 BINARY_NAME = keystream
 INSTALL_DIR = /usr/local/bin
 PLIST_DIR = ~/Library/LaunchAgents
@@ -22,30 +21,4 @@ uninstall:
 	rm -f $(PLIST_DIR)/$(PLIST_NAME)
 
 clean:
-=======
-USER := $(shell whoami)
-UID := $(shell id -u $(USER))
-BINARY_NAME = keyStream
-INSTALL_DIR = /Users/$(USER)/Applications
-PLIST_DIR = ~/Library/LaunchAgents
-
-.PHONY: install uninstall clean
-
-
-install:
-	cargo build --release
-	sudo cp target/release/$(BINARY_NAME) $(INSTALL_DIR)/$(BINARY_NAME)
-	chmod +x $(INSTALL_DIR)/$(BINARY_NAME)
-	@echo "built to $(INSTALL_DIR)/$(BINARY_NAME)"
-	sudo cp com.gauchodsp.keyStream.plist $(PLIST_DIR)/com.gauchodsp.keyStream.plist
-	chmod 644 ~/Library/LaunchAgents/com.gauchodsp.keyStream.plist
-	launchctl load $(PLIST_DIR)/com.gauchodsp.keyStream
-uninstall: 
-	sudo rm -rf $(INSTALL_DIR)/$(BINARY_NAME)
-	launchctl unload $(PLIST_DIR)/com.gauchodsp.keyStream
-	rm -f $(PLIST_DIR)/com.gauchodsp.keyStream.plist
-	sudo rm -rf target
-
-clean: 
->>>>>>> 56d9cf80e25c3b66073c1e646f13ade10f2235eb
 	cargo clean

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use keyboard::start_keyboard_listener;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-<<<<<<< HEAD
 #[cfg(target_os = "macos")]
 use core_foundation::base::TCFType;
 #[cfg(target_os = "macos")]
@@ -18,16 +17,10 @@ use core_foundation::boolean::CFBoolean;
 #[cfg(target_os = "macos")]
 use core_foundation::dictionary::CFDictionary;
 #[cfg(target_os = "macos")]
-=======
-use core_foundation::base::TCFType;
-use core_foundation::boolean::CFBoolean;
-use core_foundation::dictionary::CFDictionary;
->>>>>>> 56d9cf80e25c3b66073c1e646f13ade10f2235eb
 use core_foundation::string::CFString;
 
 const EVENT_QUEUE_SIZE: usize = 256;
 
-<<<<<<< HEAD
 #[cfg(target_os = "macos")]
 extern "C" {
     fn AXIsProcessTrustedWithOptions(options: core_foundation::dictionary::CFDictionaryRef) -> bool;
@@ -35,13 +28,6 @@ extern "C" {
 }
 
 #[cfg(target_os = "macos")]
-=======
-extern "C" {
-    fn AXIsProcessTrustedWithOptions(options: core_foundation::dictionary::CFDictionaryRef)
-        -> bool;
-}
-
->>>>>>> 56d9cf80e25c3b66073c1e646f13ade10f2235eb
 fn request_accessibility_permission() -> bool {
     let key = CFString::new("AXTrustedCheckOptionPrompt");
     let value = CFBoolean::true_value();
@@ -49,40 +35,20 @@ fn request_accessibility_permission() -> bool {
     unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef()) }
 }
 
-<<<<<<< HEAD
 #[cfg(target_os = "macos")]
-=======
-extern "C" {
-    fn AXIsProcessTrusted() -> bool;
-}
-
->>>>>>> 56d9cf80e25c3b66073c1e646f13ade10f2235eb
 fn has_accessibility_permission() -> bool {
     unsafe { AXIsProcessTrusted() }
 }
 
 fn main() {
-<<<<<<< HEAD
     #[cfg(target_os = "macos")]
     if !has_accessibility_permission() {
         eprintln!("Requesting Accessibility permission...");
         request_accessibility_permission();
-=======
-    if !has_accessibility_permission() {
-        eprintln!("Requesting Accessibility permission...");
-        request_accessibility_permission(); // opens System Settings dialog
->>>>>>> 56d9cf80e25c3b66073c1e646f13ade10f2235eb
         eprintln!("Please grant permission, then restart the app.");
         std::process::exit(1);
     }
 
-<<<<<<< HEAD
-=======
-    if let Err(e) = listen(handle_event) {
-        eprintln!("Failed to listen: {:?}", e);
-    }
-
->>>>>>> 56d9cf80e25c3b66073c1e646f13ade10f2235eb
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
 


### PR DESCRIPTION
progress so far:
 - CLI Interface: keystream runs in foreground, exit via Ctrl+C                                       
  - Global Keyboard Capture: passive observation, no interception, KeyDown/KeyUp events                
  - Key Mapping: letter keys only, home row C4-D5, top row octave higher, bottom row octave lower      
  - Audio System: cpal, default output device, real-time callback                                      
  - Polyphony: 32-voice pool, oldest voice stealing                                                    
  - Voice Structure: y1, y2, coeff, env, state, note_id                                                
  - Recursive Sine Oscillator: y[n] = 2cos(ω)y[n-1] - y[n-2] - no trig in audio thread                 
  - Envelope: linear attack/release (5ms/200ms)                                                        
  - Mixing: sum voices × env, master gain 0.1                                                          
  - Real-Time Safety: no heap alloc, no locking in audio callback                                      
  - Event Queue: crossbeam bounded channel, 256 events                                                 
  - Accessibility Permission: macOS prompt on startup